### PR TITLE
Remove websites with 4xx status

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -211,7 +211,7 @@
 
 - name: "Brace"
   license: "Commercial"
-  website: "http://brace.io/"
+  # website: "http://brace.io/" # 400 response, Feb/23/15
   language: "Web"
   description: "Brace is the new way to host websites"
 
@@ -2480,7 +2480,7 @@
 - name: "Tags"
   github: "braceio/tags"
   license: "MIT"
-  website: "http://tags.brace.io/"
+  # website: "http://tags.brace.io/" # 400 response, Feb/23/15
   language: "Python"
 
 


### PR DESCRIPTION
Necessary to complete the build.

    brace.io -> 301 -> blog.brace.io -> 400
    tags.brace.io -> 302 -> blog.brace.io/2015/01/26/goodbye/ -> 400